### PR TITLE
Refactor progress into standalone primitives with spinner and TTY detection

### DIFF
--- a/cmd/demo/formfx.go
+++ b/cmd/demo/formfx.go
@@ -1,67 +1,37 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"time"
 
-	"github.com/garaekz/tfx/progress" // Importa tu paquete de progreso
-	"github.com/garaekz/tfx/runfx"    // Importa tu runner
+	"github.com/garaekz/tfx/progress"
 )
 
 func runFormFXDemo() {
-	// 1. Crear el loop de RunFX.
-	// Usamos la vía Express para simplicidad.
-	loop := runfx.Start()
-
-	// 2. Crear el componente de barra de progreso.
-	// También usamos la vía Express. Le damos un total de 100.
+	// Create a progress bar using the express path.
 	progressBar := progress.Start(progress.ProgressConfig{
 		Total: 100,
-		Label: "Descargando archivos...",
+		Label: "Downloading files...",
 	})
 
-	// 3. Montar el componente en el loop.
-	// runfx se encargará de renderizarlo en cada tick.
-	unmount, err := loop.Mount(progressBar)
-	if err != nil {
-		fmt.Printf("Error al montar la barra de progreso: %v\n", err)
-		return
-	}
-	// Nos aseguramos de desmontar el componente al final.
-	defer unmount()
-
-	// 4. Ejecutar el loop en una goroutine (en segundo plano).
-	// Usamos un contexto para poder detenerlo más tarde.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel() // Llama a cancel() cuando main() termina para limpiar la goroutine.
-
-	go func() {
-		fmt.Println("Iniciando el loop de renderizado en segundo plano...")
-		if err := loop.Run(ctx); err != nil {
-			// Esto se imprimirá si el loop se detiene con un error,
-			// lo cual es normal si el contexto se cancela.
-			// fmt.Printf("Loop terminado con error: %v\n", err)
-		}
-		fmt.Println("Loop de renderizado detenido.")
-	}()
-
-	// 5. Simular trabajo en la goroutine principal.
-	// Aquí es donde estaría tu lógica de negocio (descargar un archivo, procesar datos, etc.).
-	fmt.Println("Iniciando tarea principal...")
+	fmt.Println("Starting main task...")
 	for i := 0; i <= 100; i++ {
-		// Actualizamos el estado del componente de progreso.
-		// El loop de runfx detectará el cambio y lo re-renderizará automáticamente.
 		progressBar.Set(i)
-		time.Sleep(30 * time.Millisecond) // Simula una pequeña cantidad de trabajo.
+		fmt.Print(progressBar.Render())
+		time.Sleep(30 * time.Millisecond)
 	}
 
-	// 6. Finalizar la barra de progreso y detener el loop.
 	progressBar.Finish()
+	fmt.Println("\nTask completed.")
 
-	// Es importante dar un pequeño margen para que el loop renderice el estado final (100%).
-	time.Sleep(50 * time.Millisecond)
-
-	// La llamada a `cancel()` (a través del `defer`) detendrá el loop.
-	fmt.Println("\nTarea completada.")
+	// Demonstrate spinner usage.
+	spinner := progress.StartSpinner(progress.SpinnerConfig{
+		Label: "Processing",
+	})
+	for i := 0; i < 20; i++ {
+		spinner.Tick()
+		fmt.Print(spinner.Render())
+		time.Sleep(100 * time.Millisecond)
+	}
+	fmt.Println("\nDone.")
 }

--- a/formfx/secret.go
+++ b/formfx/secret.go
@@ -8,17 +8,15 @@ import (
 	"github.com/garaekz/tfx/runfx"
 )
 
-// --- 1. Configuración y Renderer ---
-
-// SecretConfig contiene la configuración declarativa para un SecretPrompt.
+// SecretConfig holds configuration for a SecretPrompt.
 type SecretConfig struct {
 	Label    string
 	Confirm  bool
-	Mask     rune // El carácter a usar para enmascarar la entrada.
+	Mask     rune
 	Renderer SecretRenderer
 }
 
-// DefaultSecretConfig devuelve la configuración por defecto.
+// DefaultSecretConfig returns default options for SecretPrompt.
 func DefaultSecretConfig() SecretConfig {
 	return SecretConfig{
 		Label:    "Enter secret:",
@@ -28,35 +26,30 @@ func DefaultSecretConfig() SecretConfig {
 	}
 }
 
-// SecretRenderer define la interfaz para renderizar un componente SecretPrompt.
+// SecretRenderer defines the rendering interface for SecretPrompt.
 type SecretRenderer interface {
 	Render(s *SecretPrompt) []byte
 }
 
-// DefaultSecretRenderer es la implementación estándar.
+// DefaultSecretRenderer renders the label and masked value.
 type DefaultSecretRenderer struct{}
 
 func (r *DefaultSecretRenderer) Render(s *SecretPrompt) []byte {
-	// Dibuja el label y luego el valor enmascarado del prompt interno.
 	maskedValue := strings.Repeat(string(s.Mask), len(s.prompt.Value))
 	return fmt.Appendf(nil, "%s: %s", s.Label, maskedValue)
 }
 
-// --- 2. El Componente de Alto Nivel: SecretPrompt ---
-
-// SecretPrompt es un componente de UI para la entrada de texto secreto.
+// SecretPrompt is a component for secret text input.
 type SecretPrompt struct {
-	prompt   *InputPrompt // El primitivo que gestiona el estado del texto.
+	prompt   *InputPrompt
 	Label    string
 	Confirm  bool
 	Mask     rune
 	renderer SecretRenderer
 }
 
-// NewSecretPrompt es el constructor explícito y fuertemente tipado.
+// NewSecretPrompt builds a SecretPrompt from configuration.
 func NewSecretPrompt(cfg SecretConfig) (*SecretPrompt, error) {
-	// La lógica de confirmación se manejará en un nivel superior o en un handler especializado.
-	// Por ahora, el primitivo solo captura una entrada.
 	p := NewInputPrompt("")
 
 	renderer := cfg.Renderer
@@ -73,34 +66,20 @@ func NewSecretPrompt(cfg SecretConfig) (*SecretPrompt, error) {
 	}, nil
 }
 
-// --- 3. La Función de Conveniencia "Multipath" ---
-
-// Secret es la función de conveniencia de alto nivel.
+// Secret is a convenience function that creates a SecretPrompt.
 func Secret(opts ...any) (*SecretPrompt, error) {
 	cfg := share.OverloadWithOptions[SecretConfig](opts, DefaultSecretConfig())
 	return NewSecretPrompt(cfg)
 }
 
-// --- Métodos del Componente ---
+func (s *SecretPrompt) Done() <-chan string       { return s.prompt.Done }
+func (s *SecretPrompt) Canceled() <-chan struct{} { return s.prompt.Canceled }
 
-func (s *SecretPrompt) Done() <-chan string {
-	return s.prompt.Done
-}
+// Render uses the configured renderer.
+func (s *SecretPrompt) Render() []byte { return s.renderer.Render(s) }
 
-func (s *SecretPrompt) Canceled() <-chan struct{} {
-	return s.prompt.Canceled
-}
-
-// --- Implementación de Interfaces de RunFX ---
-
-func (s *SecretPrompt) Render() []byte {
-	return s.renderer.Render(s)
-}
-
+// OnKey delegates to the internal prompt. Confirmation logic can be added externally.
 func (s *SecretPrompt) OnKey(key runfx.Key) bool {
-	// La lógica de confirmación (pedir el secreto dos veces) se implementaría aquí,
-	// gestionando un estado interno para saber en qué paso estamos.
-	// Por simplicidad, esta versión solo delega al prompt primitivo.
 	return s.prompt.OnKey(key)
 }
 

--- a/logfx/logx_test.go
+++ b/logfx/logx_test.go
@@ -359,7 +359,7 @@ func TestCreateEntry(t *testing.T) {
 	if entry.Timestamp.IsZero() {
 		t.Error("Timestamp should not be zero")
 	}
-	if entry.Caller == nil || !strings.Contains(entry.Caller.File, "logfx.go") {
+	if entry.Caller == nil || !strings.Contains(entry.Caller.File, "logx.go") {
 		t.Errorf("Expected caller info, got %v", entry.Caller)
 	}
 
@@ -388,8 +388,8 @@ func TestGetCaller(t *testing.T) {
 	if caller == nil {
 		t.Fatal("getCaller() returned nil")
 	}
-	if !strings.Contains(caller.File, "logfx_test.go") {
-		t.Errorf("Expected file to contain logfx_test.go, got %q", caller.File)
+	if !strings.Contains(caller.File, "logx_test.go") {
+		t.Errorf("Expected file to contain logx_test.go, got %q", caller.File)
 	}
 	if !strings.Contains(caller.Function, "TestGetCaller") {
 		t.Errorf("Expected function to contain TestGetCaller, got %q", caller.Function)

--- a/progress/render.go
+++ b/progress/render.go
@@ -1,4 +1,3 @@
-// progress/render.go - REDESIGNED
 package progress
 
 import (
@@ -9,15 +8,13 @@ import (
 	"github.com/garaekz/tfx/terminal"
 )
 
-// Enhanced progress bar rendering with effects and smart color detection
+// RenderBar builds a progress bar string using theme colors.
 func RenderBar(p *Progress, detector *terminal.Detector) string {
 	percent := float64(p.current) / float64(p.total)
 
-	// Render label with theme color
 	labelColor := p.theme.RenderColor(p.theme.LabelColor, detector)
 	label := labelColor + p.label + color.Reset
 
-	// Render progress bar with effects
 	var bar string
 	if p.theme.EffectEnabled && p.effect != EffectNone {
 		bar = p.theme.RenderProgress(percent, p.width, p.effect, detector)
@@ -25,176 +22,25 @@ func RenderBar(p *Progress, detector *terminal.Detector) string {
 		bar = p.theme.renderSolidProgress(int(percent*float64(p.width)), p.width, detector)
 	}
 
-	// Render percentage with theme color
 	percentColor := p.theme.RenderColor(p.theme.PercentColor, detector)
 	percentText := percentColor + fmt.Sprintf("%3d%%", int(percent*100)) + color.Reset
 
-	// Render borders with theme color
 	borderColor := p.theme.RenderColor(p.theme.BorderColor, detector)
 	leftBorder := borderColor + "[" + color.Reset
 	rightBorder := borderColor + "]" + color.Reset
 
-	// Construct the basic bar string
-	basicBar := fmt.Sprintf("\r%s %s%s%s %s", label, leftBorder, bar, rightBorder, percentText)
+	result := fmt.Sprintf("\r%s %s%s%s %s", label, leftBorder, bar, rightBorder, percentText)
 
-	// Add time estimation if enabled and progress is started
 	if p.ShowETA && p.isStarted && p.current > 0 {
 		elapsed := time.Since(p.startTime)
 		rate := float64(p.current) / elapsed.Seconds()
-
 		if rate > 0 {
 			remaining := float64(p.total-p.current) / rate
-			eta := fmt.Sprintf("ETA: %ds", int(remaining))
-
-			// Style ETA with theme
 			etaColor := p.theme.RenderColor(p.theme.PercentColor, detector)
-			styledETA := etaColor + eta + color.Reset
-
-			return basicBar + " " + styledETA
+			eta := etaColor + fmt.Sprintf("ETA: %ds", int(remaining)) + color.Reset
+			return result + " " + eta
 		}
 	}
-
-	return basicBar
-}
-
-// Enhanced spinner rendering with color themes
-func RenderSpinner(s *Spinner, frame string, detector *terminal.Detector) string {
-	// Apply theme colors to spinner frame and message
-	frameColor := s.theme.RenderColor(s.theme.CompleteColor, detector)
-	labelColor := s.theme.RenderColor(s.theme.LabelColor, detector)
-
-	styledFrame := frameColor + frame + color.Reset
-	styledMessage := labelColor + s.message + color.Reset
-
-	return fmt.Sprintf("\r%s %s", styledFrame, styledMessage)
-}
-
-// Advanced rendering for completion messages
-func RenderCompletion(
-	theme ProgressTheme,
-	message string,
-	success bool,
-	detector *terminal.Detector,
-) string {
-	var messageColor color.Color
-	var icon string
-
-	if success {
-		messageColor = theme.CompleteColor
-		icon = "✅"
-	} else {
-		messageColor = color.MaterialRed // Error color
-		icon = "❌"
-	}
-
-	coloredMessage := theme.RenderColor(messageColor, detector) + message + color.Reset
-	return fmt.Sprintf(" %s %s", icon, coloredMessage)
-}
-
-// Multi-line progress display for complex operations
-func RenderMultiProgress(bars []*Progress, detector *terminal.Detector) string {
-	result := ""
-
-	for i, bar := range bars {
-		if i > 0 {
-			result += "\n"
-		}
-
-		// Add numbering for multiple bars
-		numberColor := bar.theme.RenderColor(bar.theme.BorderColor, detector)
-		number := numberColor + fmt.Sprintf("%d. ", i+1) + color.Reset
-
-		barRender := RenderBar(bar, detector)
-		// Remove the \r from individual bars in multi-progress
-		barRender = barRender[1:] // Remove leading \r
-
-		result += number + barRender
-	}
-
-	return result
-}
-
-// ASCII art style rendering for special occasions
-func RenderASCIIBar(p *Progress, style ASCIIStyle, detector *terminal.Detector) string {
-	percent := float64(p.current) / float64(p.total)
-	var bar string
-	filled := int(percent * float64(p.width))
-
-	labelColor := p.theme.RenderColor(p.theme.LabelColor, detector)
-	completeColor := p.theme.RenderColor(p.theme.CompleteColor, detector)
-	incompleteColor := p.theme.RenderColor(p.theme.IncompleteColor, detector)
-
-	switch style {
-	case ASCIIClassic:
-		// Classic [=====>    ] style
-		for i := 0; i < p.width; i++ {
-			if i < filled-1 {
-				bar += completeColor + "=" + color.Reset
-			} else if i == filled-1 {
-				bar += completeColor + ">" + color.Reset
-			} else {
-				bar += incompleteColor + " " + color.Reset
-			}
-		}
-	case ASCIIDots:
-		// Dots style [●●●●○○○○]
-		for i := 0; i < p.width; i++ {
-			if i < filled {
-				bar += completeColor + "●" + color.Reset
-			} else {
-				bar += incompleteColor + "○" + color.Reset
-			}
-		}
-	case ASCIIBlocks:
-		// Unicode blocks [████░░░░]
-		for i := 0; i < p.width; i++ {
-			if i < filled {
-				bar += completeColor + "█" + color.Reset
-			} else {
-				bar += incompleteColor + "░" + color.Reset
-			}
-		}
-	}
-
-	label := labelColor + p.label + color.Reset
-	percentColor := p.theme.RenderColor(p.theme.PercentColor, detector)
-	percentText := percentColor + fmt.Sprintf(" %3d%%", int(percent*100)) + color.Reset
-
-	return fmt.Sprintf("\r%s [%s]%s", label, bar, percentText)
-}
-
-// ASCII style types
-type ASCIIStyle int
-
-const (
-	ASCIIClassic ASCIIStyle = iota
-	ASCIIDots
-	ASCIIBlocks
-)
-
-// Render with dynamic width based on terminal size
-func RenderResponsiveBar(p *Progress, maxWidth int, detector *terminal.Detector) string {
-	// Adjust bar width based on available space
-	labelLen := len(p.label)
-	percentLen := 5 // " 100%"
-	borderLen := 4  // " [" + "] "
-
-	availableWidth := min(
-		// Minimum width
-		max(maxWidth-labelLen-percentLen-borderLen,
-
-			10),
-		// Maximum width
-		60)
-
-	// Temporarily adjust width for rendering
-	originalWidth := p.width
-	p.width = availableWidth
-
-	result := RenderBar(p, detector)
-
-	// Restore original width
-	p.width = originalWidth
 
 	return result
 }

--- a/progress/spinner.go
+++ b/progress/spinner.go
@@ -1,119 +1,73 @@
 package progress
 
 import (
+	"fmt"
 	"sync"
-	"time"
 
+	"github.com/garaekz/tfx/color"
+	"github.com/garaekz/tfx/runfx"
 	"github.com/garaekz/tfx/terminal"
 )
 
-// --- 1. El Componente de Alto Nivel: Spinner ---
-
-// Spinner es un componente de UI que muestra una barra de progreso.
-// Es un componente pasivo diseñado para ser montado en un runfx.Loop.
+// Spinner is a simple animated indicator that cycles through frames.
 type Spinner struct {
-	// Estado
-	total     int
-	current   int
-	label     string
-	startTime time.Time
-	isStarted bool
-
-	// Configuración de Apariencia
-	width    int
-	theme    SpinnerTheme
-	style    SpinnerStyle
-	effect   SpinnerEffect
+	frames   []string
+	index    int
+	label    string
+	theme    ProgressTheme
 	detector *terminal.Detector
-	ShowETA  bool
+	isTTY    bool
 
 	mu sync.Mutex
 }
 
-// newSpinner es el constructor interno que ensambla el componente.
-// Es llamado por la API pública (Start, NewSpinnerBuilder).
+// newSpinner creates a Spinner using the provided configuration.
 func newSpinner(cfg SpinnerConfig) *Spinner {
+	detect := cfg.DetectTTY
+	if detect == nil {
+		detect = runfx.DetectTTY
+	}
+	tty := detect()
+
 	return &Spinner{
-		total:    cfg.Total,
+		frames:   cfg.Frames,
 		label:    cfg.Label,
-		width:    cfg.Width,
 		theme:    cfg.Theme,
-		style:    cfg.Style,
-		effect:   cfg.Effect,
-		detector: terminal.NewDetector(cfg.Writer), // Asume que el detector se basa en el writer.
-		ShowETA:  cfg.ShowETA,
+		detector: terminal.NewDetector(cfg.Writer),
+		isTTY:    tty.IsTTY,
 	}
 }
 
-// --- 2. Implementación de Interfaces de RunFX ---
+// Render returns the current spinner frame with the label.
+// When not running in a TTY, only the label is returned.
+func (s *Spinner) Render() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-// Render implementa la interfaz runfx.Visual.
-// Es llamado por el runfx.Loop en cada ciclo de renderizado.
-func (p *Spinner) Render() []byte {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if !p.isStarted {
-		return nil // No renderiza nada si no ha comenzado.
+	if !s.isTTY {
+		return s.label
 	}
 
-	// Llama a la lógica de renderizado existente para generar el string.
-	rendered := RenderBar(p, p.detector)
-	return []byte(rendered)
+	frame := s.frames[s.index%len(s.frames)]
+	frameColor := s.theme.RenderColor(s.theme.CompleteColor, s.detector)
+	labelColor := s.theme.RenderColor(s.theme.LabelColor, s.detector)
+
+	styledFrame := frameColor + frame + color.Reset
+	styledLabel := labelColor + s.label + color.Reset
+
+	return fmt.Sprintf("\r%s %s", styledFrame, styledLabel)
 }
 
-// Tick implementa la interfaz runfx.Updatable.
-// Es llamado por el runfx.Loop en cada tick, útil para efectos animados.
-func (p *Spinner) Tick(now time.Time) {
-	// La lógica para efectos de animación (pulsos, spinners) iría aquí.
-	// Por ahora, no hace nada, pero el contrato está cumplido.
+// Tick advances the spinner to the next frame.
+func (s *Spinner) Tick() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.index = (s.index + 1) % len(s.frames)
 }
 
-// OnResize implementa la interfaz runfx.Visual.
-func (p *Spinner) OnResize(cols, rows int) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	// Lógica opcional para ajustar el ancho de la barra al tamaño del terminal.
-	if cols > 0 && cols < p.width+20 {
-		p.width = max(cols-20, 10)
-	}
-}
-
-// --- 3. Métodos para Manipular el Estado ---
-
-// Set actualiza el valor de progreso actual.
-func (p *Spinner) Set(current int) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if !p.isStarted {
-		p.isStarted = true
-		p.startTime = time.Now()
-	}
-	p.current = min(current, p.total)
-}
-
-// Add incrementa el progreso en una cantidad dada.
-func (p *Spinner) Add(amount int) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if !p.isStarted {
-		p.isStarted = true
-		p.startTime = time.Now()
-	}
-	p.current = min(p.current+amount, p.total)
-}
-
-// SetLabel actualiza la etiqueta de la barra de progreso.
-func (p *Spinner) SetLabel(label string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.label = label
-}
-
-// Finish establece el progreso al 100%.
-// En esta arquitectura, no detiene el loop ni se desmonta a sí mismo.
-func (p *Spinner) Finish() {
-	p.Set(p.total)
+// SetLabel updates the spinner's label text.
+func (s *Spinner) SetLabel(label string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.label = label
 }

--- a/progress/style.go
+++ b/progress/style.go
@@ -9,7 +9,7 @@ const (
 	ProgressStyleAscii
 )
 
-// StyleChars contiene los símbolos de cada style
+// styleChars maps each style to its filled and empty symbols.
 var styleChars = map[ProgressStyle]struct {
 	Filled, Empty string
 }{

--- a/runfx/api.go
+++ b/runfx/api.go
@@ -86,9 +86,9 @@ func (b *LoopBuilder) AutoTick() *LoopBuilder {
 	return b
 }
 
-// --- Vía 4 (Functional Options) ---
-// This path provides a composable way to configure a loop.
-// As noted in the TFX philosophy, this is often considered an alternative to the DSL path.
+// --- Functional Options Path ---
+// This approach provides a composable way to configure a loop.
+// As noted in the TFX philosophy, it can serve as an alternative to the DSL path.
 
 // StartWith creates and returns a new Loop configured with the provided functional options.
 // It is the primary entry point for the Functional Options path.


### PR DESCRIPTION
## Summary
- Introduce configurable spinner primitive with terminal detection fallback
- Streamline progress bar renderer and demo, showing both progress bar and spinner
- Translate remaining Spanish comments across modules to English

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68902d74acf4832bb51203ccba0953a5